### PR TITLE
Fix 12.0.10

### DIFF
--- a/kg.py
+++ b/kg.py
@@ -79,12 +79,8 @@ def generate_single(k: dsa.DSAPrivateKey, id1: int, id2: int, hwid: str) -> str:
     return f.format(serial, id1, id2, sig)
 
 
-def generate_all(k: dsa.DSAPrivateKey, hwid: str, version: int) -> str:
-    ident = { 9: 0x90,
-             10: 0xa0,
-             11: 0xb0,
-             12: 0xc0}
-    yield generate_single(k, 0x0, ident[version], hwid)
+def generate_all(k: dsa.DSAPrivateKey, hwid: str, ver: int) -> str:
+    yield generate_single(k, 0x2 if ver >= 12 else 0x0, ver << 4, hwid)
     for i in range(0x40, 0xff + 1):
         yield generate_single(k, i, 0x10, hwid)
     for i in range(0x8000, 0x80ff + 1):
@@ -101,7 +97,7 @@ team_r2r_key = construct_key(
 
 hwid = args.hwid.upper()
 if len(hwid) == 24:
-    hwid = "-".join((hwid[:4], hwid[4:8], hwid[8:12], hwid[12:16], hwid[16:20], hwid[20:]))
+    hwid = "-".join(hwid[i:i+4] for i in range(0, 24, 4))
 assert re.fullmatch(r"([0-9A-F]{4}-){5}[0-9A-F]{4}", hwid), f"Expected hardware ID like 1111-1111-1111-1111-1111-1111, not {hwid}"
 
 lines = generate_all(team_r2r_key, hwid, args.version)


### PR DESCRIPTION
As of Ableton 12.0.10, id1 header must be 02. I also fixed the unnecessary ident lookup table and simplified the hardware code dash adder from my previous PR.